### PR TITLE
Actually address the PY_SSIZE_T_CLEAN issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     long_description = open(readmePath, "rt").read()
 
     setup(name='crc16',
-          version='0.1.1',
+          version='0.1.2',
           description='Library for calculating CRC16',
           author='Gennady Trafimenkov',
           author_email='gennady.trafimenkov@gmail.com',

--- a/src/_crc16module.c
+++ b/src/_crc16module.c
@@ -19,6 +19,7 @@
  *
  * **************************************************************************/
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 /* table for calculating CRC
@@ -91,7 +92,7 @@ static PyObject *
 _crc16_crc16xmodem(PyObject *self, PyObject *args)
 {
     const unsigned char* data;
-    int data_len;
+    Py_ssize_t data_len;
     unsigned int crc = 0;
     unsigned int result;
 


### PR DESCRIPTION
Current versions of python report warnings or even errors like this:

```
DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
```

This PR users the required `Py_ssize_t` and sets the appropriate `PY_SSIZE_T_CLEAN`. For details see the first not at https://docs.python.org/3/c-api/arg.html#arg-parsing.

Fixes #5
Improvement on #7, which only sets `PY_SSIZE_T_CLEAN`, but doesn't actually address the issue.

Also updates the version to `0.1.2`.
